### PR TITLE
Tensor size mismatch error when running tests

### DIFF
--- a/src/assignments/linear_classifier.py
+++ b/src/assignments/linear_classifier.py
@@ -105,7 +105,7 @@ class LinearClassifier:
             logits: The logits of the model. Tensor of shape (N, C)
 
         """
-        logits = torch.zeros((X.shape[0], self.num_classes))
+        logits = torch.zeros((X.shape[0], self.num_features))
 
         # ▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱ Assignment 3.1 ▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰ #
         # TODO:                                                             #


### PR DESCRIPTION
When running the tests, the following error appears:  
`The size of tensor a (5) must match the size of tensor b (10) at non-singleton dimension 1`.  

This error is confusing when implementing forward function. I believe the issue stems from the [initialization](https://github.com/urob-ctu/classification/blob/main/src/assignments/linear_classifier.py#L108).  

I propose replacing the current initialization with:  
```python
logits = torch.zeros((X.shape[0], self.num_features))
```
This should resolve the size mismatch and make the implementation clearer.