### PR TITLE
Add tips for LinearClassifier assignments

### DIFF
--- a/src/assignments/linear_classifier.py
+++ b/src/assignments/linear_classifier.py
@@ -174,7 +174,7 @@ class LinearClassifier:
         # should be the cross-entropy loss with L2 regularization.          #
         #                                                                   #
         # HINT: You may find torch.nn.CrossEntropyLoss() useful.            #
-        #                                                                   #
+        # HINT: Use self.reg as your regularization hyperparameter.         #
         # Good luck!                                                        #
         # ▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰ #
         # 🌀 INCEPTION 🌀 (Your code begins its journey here. 🚀 Do not delete this line.)
@@ -199,7 +199,7 @@ class LinearClassifier:
         # should be the cross-entropy loss with L2 regularization.          #
         #                                                                   #
         # HINT: You may find torch.nn.CrossEntropyLoss() useful.            #
-        #                                                                   #
+        # HINT: Use self.learning_rate to scale the updates to the weights. #
         # Good luck!                                                        #
         # ▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰▱▰ #
         # 🌀 INCEPTION 🌀 (Your code begins its journey here. 🚀 Do not delete this line.)


### PR DESCRIPTION
This pull request adds tips regarding the parameters `reg` and `learning_rate`, which were not clearly specified in the Jupyter notebooks or mentioned in the TODO blocks in functions loss, _update_weights.

By including these explanations, I aim to improve the clarity of the assignments.